### PR TITLE
#315 Use today as query date

### DIFF
--- a/lib/blocs/request_manager/online_request_manager.dart
+++ b/lib/blocs/request_manager/online_request_manager.dart
@@ -94,12 +94,13 @@ class OnlineRequestManager implements RequestManager {
     String mode,
   ) async {
     final urlOtpEndpoint = GlobalConfiguration().getString("urlOtpEndpoint");
+
     Uri request = Uri
       .parse(urlOtpEndpoint + planPath)
       .replace(queryParameters: {
         "fromPlace": from.toString(),
         "toPlace": to.toString(),
-        "date": "01-01-2018",
+        "date": _todayMonthDayYear(),
         "numItineraries":"5",
         "mode": mode
       });
@@ -117,6 +118,13 @@ class OnlineRequestManager implements RequestManager {
     } catch (e) {
       throw FetchOnlineRequestException(e);
     }
+  }
+
+  String _todayMonthDayYear() {
+    var today = new DateTime.now();
+    return "${today.month.toString().padLeft(2,'0')}-" +
+      "${today.day.toString().padLeft(2,'0')}-" +
+      "${today.year.toString()}";
   }
 
   String _localizedErrorForPlanError(


### PR DESCRIPTION
Fetch the current date and format in Month-Dy-Year Order for the API
request.

No using intl lib, because it would cause overhead, and we have a fixed
format here.

Before this fix, custom GTFS server which only have a recently dated
schedule would not return results.