### PR TITLE
No trufi icon in app drawer

### DIFF
--- a/lib/widgets/trufi_drawer.dart
+++ b/lib/widgets/trufi_drawer.dart
@@ -112,7 +112,7 @@ class TrufiDrawerState extends State<TrufiDrawer> {
           Divider(),
           if (cfg.url.website != "")
             _buildWebLinkItem(
-              CustomIcons.trufi,
+              Icons.web,
               localization.readOurBlog(),
               cfg.url.website,
             ),


### PR DESCRIPTION
The Trufi icon should not be used here, because it makes derived apps
harder / impossible to customize properly.

Also the Trufi icon does not make much sense here, as it is a web page
link and a web symbol should be used.